### PR TITLE
Adelaide meetup group is defunct (removed).

### DIFF
--- a/02_useR_groups_oceania.Rmd
+++ b/02_useR_groups_oceania.Rmd
@@ -6,7 +6,6 @@ knit: "bookdown::preview_chapter"
 
 ### Australia
 
-  * Adelaide: [Adelaide R-users Group](http://www.meetup.com/Adelaide-R-users-group/)
   * Brisbane: [BrisRUG](http://www.meetup.com/Brisbane-R-User-Group-BrisRUG/)
   * Brisbane: [BURGr](http://www.meetup.com/Brisbane-Users-of-R-Group-BURGr/)
   * Canberra: [CANRUG](http://www.meetup.com/Canberra-R-Users-Group/)


### PR DESCRIPTION
I do want to start a new one, but am yet to find the right configuration (i.e. free).