### PR TITLE
added Doha, fixed duplicate Nigeria

### DIFF
--- a/02_useR_groups_middle_east_africa.Rmd
+++ b/02_useR_groups_middle_east_africa.Rmd
@@ -32,10 +32,11 @@ knit: "bookdown::preview_chapter"
 ### Nigeria
 
   * Lagos: [Lagos R Users Group](http://www.meetup.com/Lagos-R-Users-Group/)
-
-### Nieria
-
   * Offa: [Offa R Users Group](http://www.meetup.com/FEDPOFA-R-Users-Group/)
+
+### Qatar
+
+  * Doha: [Doha R User Group](https://www.meetup.com/doha-rug)
 
 ### Senegal
 


### PR DESCRIPTION
You still have a page for Africa *and* a Middle East/Africa page.