### PR TITLE
Add Osnabrück R und Data Science

### DIFF
--- a/02_useR_groups_europe.Rmd
+++ b/02_useR_groups_europe.Rmd
@@ -46,6 +46,7 @@
   *  Munich: [Applied R Munich](http://www.meetup.com/Applied-R-Munich)
   *  Munich: [Munich useR Group](http://www.meetup.com/munich-useR-group/)
   *  Nürnberg: [NürnbergR](https://www.xing.com/net/ruser-nuernberg/)
+  *  Osnabrück: [Osnabrück R und Data Science](https://www.meetup.com/de-DE/Osnabrueck-R-und-Data-Science/)
   *  Wiesbaden: [Wiesbaden R Users Group](http://www.meetup.com/Wiesbaden-R-Users-Group)
   
 ### Greece


### PR DESCRIPTION
I added the Osnabrück R and Data Science meetup. We want to be open to other languages too (thus the Data Science in our group's name) but I think we still qualify as an R user group.