### PR TITLE
Re-instated Adelaide RUG

### DIFF
--- a/02_useR_groups_oceania.Rmd
+++ b/02_useR_groups_oceania.Rmd
@@ -6,6 +6,7 @@ knit: "bookdown::preview_chapter"
 
 ### Australia
 
+  * Adelaide: [ARUG](https://www.meetup.com/Adelaide-R-Users/)
   * Brisbane: [BrisRUG](http://www.meetup.com/Brisbane-R-User-Group-BrisRUG/)
   * Brisbane: [BURGr](http://www.meetup.com/Brisbane-Users-of-R-Group-BURGr/)
   * Canberra: [CANRUG](http://www.meetup.com/Canberra-R-Users-Group/)


### PR DESCRIPTION
The Adelaide RUG has been reborn thanks to R Consortium funding.

(I know, it was only *just* removed, but this is a new one and I didn't know this was happening when I removed the old one).