### PR TITLE
Mistake in barcelona rladies

### DIFF
--- a/03-Rladies.Rmd
+++ b/03-Rladies.Rmd
@@ -15,7 +15,7 @@ knit: "bookdown::preview_chapter"
 ## Spain
 
   * Madrid: [Madrid](https://www.meetup.com/rladies-madrid/R-Ladies); [\@RLadies](https://twitter.com/RLadiesMAD)
-  * Barcelona: [Madrid](http://www.meetup.com/es-ES/rladies-barcelona/); [\@RLadies](https://twitter.com/rladiesbcn)
+  * Barcelona: [Barcelona](http://www.meetup.com/es-ES/rladies-barcelona/); [\@RLadies](https://twitter.com/rladiesbcn)
 
 ## Turkey
 


### PR DESCRIPTION
Changes Madrid to Barcelona in link