### PR TITLE
Seperate Hong Kong and Macau usergroups from China usergroup

### DIFF
--- a/02_useR_groups_asia.Rmd
+++ b/02_useR_groups_asia.Rmd
@@ -3,13 +3,11 @@
 ### China
 
   * Chengdu: [Chengdu R User's Group](https://www.meetup.com/Chengdu-R-Users-Group/events/218924116/)
-  * Hong Kong: [Hong Kong R User Group](https://www.facebook.com/groups/hkrusers/)
-  * Macao: [R-Research](http://groupspaces.com/R-research/)
   * Xiamen: [XMU-R](https://www.meetup.com/RGROUP/)
 
-### Macao
-  
-  * Macao: [Macao R Language Beginners Study Group](https://www.meetup.com/Macao-R-Learning-Meetup/)
+### Hong Kong
+
+  * Hong Kong: [Hong Kong R User Group](https://www.facebook.com/groups/hkrusers/)
 
 ### India
 
@@ -27,6 +25,11 @@
   * Osaka: [Osaka.R](https://sites.google.com/site/osakarwiki/)
   * Tokyo: [Tokyo.R](https://groups.google.com/group/r-study-tokyo)
   * Tsukuba: [sukuba.R](http://wiki.livedoor.jp/syou6162/)
+
+### Macau
+
+  * Macau: [R-Research](http://groupspaces.com/R-research/)
+  * Macau: [Macao R Language Beginners Study Group](https://www.meetup.com/Macao-R-Learning-Meetup/)
 
 ### Malaysia
 


### PR DESCRIPTION
I know it is political but grouping Hong Kong and Macau user groups under China is a dangerous idea. Following the same logic of grouping Hong Kong and Macau under China, some might argue you should group Taiwan groups under China as well.

There is an independent Macau section in the current version already, so I don't think an independent Hong Kong section is a bad idea.
