### PR TITLE
Add Tampa R Users Group

### DIFF
--- a/02_useR_groups_north_america.Rmd
+++ b/02_useR_groups_north_america.Rmd
@@ -63,6 +63,7 @@ knit: "bookdown::preview_chapter"
 #### Florida {-} 
 
   * Gainsesville: [R Users Group, Gainesville](https://www.meetup.com/R-Users-Group-Gainesville-FL/)
+  * Tampa: [Tampa R Users Group](https://www.meetup.com/Tampa-R-Users-Group/); [@UseRTampa](https://twitter.com/UseRTampa)
 
 #### Georgia {-}
 

--- a/02_useR_groups_north_america.Rmd
+++ b/02_useR_groups_north_america.Rmd
@@ -63,7 +63,7 @@ knit: "bookdown::preview_chapter"
 #### Florida {-} 
 
   * Gainsesville: [R Users Group, Gainesville](https://www.meetup.com/R-Users-Group-Gainesville-FL/)
-  * Tampa: [Tampa R Users Group](https://www.meetup.com/Tampa-R-Users-Group/); [@UseRTampa](https://twitter.com/UseRTampa)
+  * Tampa: [Tampa R Users Group](https://www.meetup.com/Tampa-R-Users-Group/); [\@UseRTampa](https://twitter.com/UseRTampa)
 
 #### Georgia {-}
 


### PR DESCRIPTION
Inserted relevant links for newly founded Tampa R Users Group in 02_useR_groups_north_america.Rmd 