### PR TITLE
Add EARL London 2018

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -40,6 +40,7 @@ The format for listing an R event is
 
 ### September
 
+ * September 11-13: [EARL London 2018](https://earlconf.com/london/). London, United Kingdom. [@earlconf](https://twitter.com/earlconf)
  * September 12-14: The Use of R in Official Statistics. The Hague, The Netherlands. [\@uRos2018](https://twitter.com/uRos2018)
 
 ## 2017 {-}


### PR DESCRIPTION
EARL London Conference dates will be 11th – 13th September 2018 at The Tower Hotel, St Katharine's Way, London E1W 1LD.

[EARL conference](https://earlconf.com/)
Hosted by [Mango Solutions](https://www.mango-solutions.com/)