### PR TITLE
Include R Day - Curitiba, Brazil

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -30,6 +30,7 @@ The format for listing an R event is
 ### May
 
   * May: [The European #rstats Users Meeting](http://2018.erum.io/). Budapest, Hungary. [\@erum2018](https://twitter.com/erum2018)
+  * May 22: [R Day](http://rday.leg.ufpr.br/). Curitiba, Brazil. [\@LEG_UFPR](https://twitter.com/LEG_UFPR)
 
 ### June
 


### PR DESCRIPTION
R Day - National Meeting of R users is an event to congregate users and
developers of R in an environment for the exchange of experiences, learning
and contacts.

R Day will happen in UFPR, Curitiba (PR), Brazil, on May 22, 2018. The goal of R Day is to bring together an active and large, though sparse, community of R users in Brazil.

This will be the first event of R in Brazil officially endorsed by The R Foundation.

Thanks.
