### PR TITLE
removing inactive groups, fixing links

### DIFF
--- a/02_useR_groups_asia.Rmd
+++ b/02_useR_groups_asia.Rmd
@@ -40,12 +40,11 @@
 
 ### Philippines
 
-  * Cebu: [CRUG](https://www.meetup.com/Cebu-R-Users-Group-CRUG/)
   * Manila: [R Users Group](https://www.meetup.com/R-Users-Group-Philippines/)
 
 ### Singapore
 
-  * Singapore: [R User Group](https://www.meetup.com/R-Users-Group-Philippines/)
+  * Singapore: [R User Group](https://www.meetup.com/R-User-Group-SG/)
 
 ### South Korea
 
@@ -64,7 +63,7 @@
 
 ### Thailand
 
-  * Chang Mai: [Chang Mai R User Group](http://chiangmair.wordpress.com/)
+  * Chang Mai: [Chang Mai R User Group](https://www.facebook.com/Chiang-Mai-R-362933103793288/)
 
 ### Viet Nam
 


### PR DESCRIPTION
- Cebu last meet-up recorded in 2015

> Unfortunately, since early 2015, there has been no activities for this meetup group. I have relocated outside Cebu since early 2015 and I have not found anyone yet who is willing to run this group. Anybody interested in R is still welcome to join this meetup group until we find someone who is willing to spend time in organizing future meetups.

- Chiang Mai wordpress page not updated since a long time ago, Facebook link seems slightly more active (activity <1 year ago)

- SG link mistakenly pointed to philippines