### PR TITLE
Add R User Group of Nepal

### DIFF
--- a/02_useR_groups_asia.Rmd
+++ b/02_useR_groups_asia.Rmd
@@ -33,6 +33,12 @@
 ### Malaysia
 
   * Kuala Lumpur: [myRUG](https://www.meetup.com/MY-RUserGroup/)
+  
+  
+### Nepal
+
+  * Nepal: [R User Group Nepal](https://www.facebook.com/groups/969181646600442/)
+  
 
 ### Pakistan
 


### PR DESCRIPTION
Recently, we have successfully started R User Group in Nepal. 

Our links:
Website: https://www.r-nepal.org
Facebook group : https://www.facebook.com/groups/969181646600442/