### PR TITLE
Add CDSB 2019 Workshop (part of EBM 2019)

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -55,6 +55,7 @@ The format for listing an R event is
 
   * July 9-12: [useR! 2019](http://www.user2019.fr/). Toulouse, France. [\@UseR2019_Conf](https://twitter.com/UseR2019_Conf)
   * July 9-12: [Riot 2019](http://riotworkshop.github.io/). Toulouse, France.
+  * July 29-August2: [CDSB Workshop 2019](https://comunidadbioinfo.github.io/post/building-tidy-tools-cdsb-runconf-2019/#.XP6i_dNKi50) as part of [EBM2019](http://congresos.nnb.unam.mx/TIB2019/). Cuernavaca, Mexico.
 
 ### August
 


### PR DESCRIPTION
Added the CDSB 2019 R workshop to the list of events. It's a one week workshop that will cover the Building Tidy Tools workshop material (by Charlotte and Hadley Wickham) plus involve two days of building R packages like in rOpenSci runconf18. At EMB2019 other instructors will also teach a one week introduction to R and RStudio course.