### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # R meetings and conferences
 [![Build Status](https://travis-ci.org/jumpingrivers/meetingsR.png?branch=master)](https://travis-ci.org/jumpingrivers/meetingsR) 
 
-This site attempts to list R conferences and local useR groups. Please 
-feel free to add any missing group or conference. 
+This site attempts to list R conferences and local useR groups. 
 
-To propose a change, just click the pencil icon
-in the top left hand corner of the [web](https://jumpingrivers.github.io/meetingsR/) 
+For instance:
+ - [Asia](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_asia.Rmd)
+ - [Middle East/Africa](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_middle_east_africa.Rmd)
+ - [North America](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_north_america.Rmd)
+ - [South America](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_south_america.Rmd)
+ - [Europe](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_europe.Rmd)
+ - [Ocenia](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_ocenia.Rmd)
+
+Please feel free to add any missing group or conference. 
+
+To propose a change, just click the pencil icon in the top left hand corner of the [web](https://jumpingrivers.github.io/meetingsR/) 
 version.
 
 Keep up to date with [\@rstats_meetings](https://twitter.com/rstats_meetings) 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ For instance:
  - [Europe](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_europe.Rmd)
  - [Ocenia](https://github.com/jumpingrivers/meetingsR/blob/master/02_useR_groups_ocenia.Rmd)
 
+Also consider:
+ - [Rladies](https://github.com/jumpingrivers/meetingsR/blob/master/03-Rladies.Rmd)
+ - [Events](https://github.com/jumpingrivers/meetingsR/blob/master/01-events.Rmd)
 Please feel free to add any missing group or conference. 
 
 To propose a change, just click the pencil icon in the top left hand corner of the [web](https://jumpingrivers.github.io/meetingsR/) 


### PR DESCRIPTION
Added List of Continents for precise information of useR groups in various continents. 
Redirecting users directly to the groups through links, saving time in searching files in repo.
Continents are arranged in decreasing order of size, hence more detailed information