### PR TITLE
Remove Osnabrück R and Data Science

### DIFF
--- a/02_useR_groups_europe.Rmd
+++ b/02_useR_groups_europe.Rmd
@@ -58,7 +58,6 @@
   *  Munich: [Applied R Munich](https://www.meetup.com/Applied-R-Munich)
   *  Münster: [MünsteR (R Users Group)](https://www.meetup.com/Munster-R-Users-Group)
   *  Nürnberg: [NürnbergR](https://www.xing.com/net/ruser-nuernberg/)
-  *  Osnabrück: [Osnabrück R und Data Science](https://www.meetup.com/de-DE/Osnabrueck-R-und-Data-Science/)
   *  Wiesbaden: [Wiesbaden R Users Group](https://www.meetup.com/Wiesbaden-R-Users-Group)
   
 ### Greece `r get_btn()`


### PR DESCRIPTION
Sadly, the meetup does not exist anymore (I was one of the founders) and the link is dead.