### PR TITLE
Added hta worksop

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -25,6 +25,7 @@ The format for listing an R event is
 
 ### June
 
+  * June 9: [R for Health Technology Assessment (HTA) workshop](https://r-hta.org/events/workshop/2023/). York, UK. **Note**: This is part of a larger online event (see virtual events section).
   * June 21-23: [Rencontres R 2023](https://twitter.com/rencontres_r). Avignon, France. [\@rencontres_R](https://twitter.com/rencontres_r)
   
 ### May

--- a/04-virtual.Rmd
+++ b/04-virtual.Rmd
@@ -16,6 +16,7 @@ The format for listing a Virtual R event is
 
 ### June
 
+  * June 8-12: [R for Health Technology Assessment (HTA) workshop](https://r-hta.org/events/workshop/2023/).
   * June 6-9: [R / Medicine](https://events.linuxfoundation.org/r-medicine/). [\@r_medicine](https://twitter.com/r_medicine).
 
 ### March


### PR DESCRIPTION
@csgillespie I might need your input on this one - This event runs from Thursday - Monday online, and Friday is Hybrid, and ticketing is for either the whole thing virtually, or the virtual bits plus in person, but not in person alone - I've added a note to that effect on the events listing and referred to the virtual listing. Is that the best way to do it, or should I take that out and let the link do the talking?