### PR TITLE
Add NHS RPySOC 2024

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -13,7 +13,7 @@ The format for listing an R event is
 ### November
 
   * November 6-8: [III Congreso & XIV Jornadas de Usuarios de R](https://www.imus.us.es/congresos/IIIRqueR/). Sevilla, Spain.
-  * November 21-22: [NHS-R / NHS.Pycom Open Source Conference (NHS RPySOC 2024)](https://nhsrcommunity.com/events/save-the-date-nhs-r-nhs-pycom-open-source-conference-nhs-rpysoc-2024/). Birmingham, UK. [@NHSrCommunity@fosstodon.org](https://fosstodon.org/@NHSrCommunity)
+  * November 21-22: [NHS-R / NHS.Pycom Open Source Conference (NHS RPySOC 2024)](https://nhsrcommunity.com/events/#event_type-conferences). Birmingham, UK. [@NHSrCommunity@fosstodon.org](https://fosstodon.org/@NHSrCommunity)
   * November 27-29: [uRosConf](https://r-project.ro/conference2024.html). Athens, Greece. [\@uRosconf](https://twitter.com/uRosconf)
 
 ### October

--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -13,6 +13,7 @@ The format for listing an R event is
 ### November
 
   * November 6-8: [III Congreso & XIV Jornadas de Usuarios de R](https://www.imus.us.es/congresos/IIIRqueR/). Sevilla, Spain.
+  * November 21-22: [NHS-R / NHS.Pycom Open Source Conference (NHS RPySOC 2024)](https://nhsrcommunity.com/events/save-the-date-nhs-r-nhs-pycom-open-source-conference-nhs-rpysoc-2024/). Birmingham, UK. [@NHSrCommunity@fosstodon.org](https://fosstodon.org/@NHSrCommunity)
   * November 27-29: [uRosConf](https://r-project.ro/conference2024.html). Athens, Greece. [\@uRosconf](https://twitter.com/uRosconf)
 
 ### October

--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -13,7 +13,7 @@ The format for listing an R event is
 ### November
 
   * November 6-8: [III Congreso & XIV Jornadas de Usuarios de R](https://www.imus.us.es/congresos/IIIRqueR/). Sevilla, Spain.
-  * November 21-22: [NHS-R / NHS.Pycom Open Source Conference (NHS RPySOC 2024)](https://nhsrcommunity.com/events/#event_type-conferences). Birmingham, UK. [@NHSrCommunity@fosstodon.org](https://fosstodon.org/@NHSrCommunity)
+  * November 21-22: [NHS-R / NHS.Pycom Open Source Conference (NHS RPySOC 2024)](https://nhsrcommunity.com/events/#event_type-conferences). Birmingham, UK. [\@NHSrCommunity\@fosstodon.org](https://fosstodon.org/@NHSrCommunity)
   * November 27-29: [uRosConf](https://r-project.ro/conference2024.html). Athens, Greece. [\@uRosconf](https://twitter.com/uRosconf)
 
 ### October


### PR DESCRIPTION
Adding the NHS RPYSoc conference for November 2024