### PR TITLE
Add posit conf 2025 in 01-events.Rmd

### DIFF
--- a/01-events.Rmd
+++ b/01-events.Rmd
@@ -7,6 +7,11 @@ knit: "bookdown::preview_chapter"
 The format for listing an R event is
 
   * Date: [event name & link](http://www.example.com). Town, Country. Twitter name.
+
+## 2025 `r get_btn()` {-}
+
+### September
+  * September 16-18: [posit::conf](https://posit.co/). Atlanta, GA, USA.  [\@posit_pbc](https://twitter.com/posit_pbc).
   
 ## 2024 `r get_btn()` {-}
 


### PR DESCRIPTION
Hi! First, thanks for this page, it's really helpfull to find all the conferences about #rstats listed in one place.

I saw on [Posit's webpage](https://posit.co/blog/five-highlights-from-posit-conf-2024/) that they have a date for the conf in 2025.

This PR add's that event to the list.






